### PR TITLE
fix: only decode proper CIDs as CIDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ half = "1.2.0"
 serde = { version = "1.0.14", default-features = false }
 
 [dev-dependencies]
+serde_bytes = "0.11.5"
 serde_derive = { version = "1.0.14", default-features = false }
 
 [features]


### PR DESCRIPTION
Basically, I spent hours digging through randoms serde stuff and this is as close as I can get to idiomatic upstream.

The main difference is: upstream doesn't really support "deserialize any" for newtypes. So we have to hack it a bit and just assume that we only have one newtype (which, luckily, is correct).